### PR TITLE
Feature/fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,3 +135,9 @@ Nun kann man mit `git status` die Änderungen sehen. Mit `git add` staged man di
 
 ### Patch schicken
 Auf der Mailingliste franken-dev@freifunk.net kannst du natürlich jederzeit Fragen stellen, falls etwas nicht klar sein sollte.
+
+## Hinzufügen von Paketen zum Image
+
+Das Hinzufügen von Paketen sollte mit Bedacht erfolgen, da dies (bei unvorsichtiger Konfiguration( den Betrieb des Routers und eventuell des Freifunk-Netzes beeinträchtigen könnte.  
+Mit dem Firmware-Verzeichnis als Arbeitsverzeichnis kann mittels des Befehls `./build/<target>/scripts/feeds install <paket>` ein Paket zur menuconfig hinzugefügt werden.
+Mittels des schon bekannten `./buildscript config openwrt` kann das Paket dann ausgewählt werden. Es wird beim anschließenden Build zum Image hinzugefügt.

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ Freifunk ist eine nicht-kommerzielle Initiative für freie Funknetzwerke. Jeder 
 * `cd firmware`
 
 ### Erste Schritte
-Mit Hilfe der Community-Files werden Parameter, wie die ESSID, der Kanal sowie z.B. die Netmon-IP gesetzt. Diese Einstellungen sind Community weit einheitlich und müssen i.d.R. nicht geändert werden.
-* `./buildscript selectcommunity community/franken.cfg`
+
 Je nach dem, für welche Hardware die Firmware gebaut werden soll muss das BSP gewählt werden:
-* `./buildscript selectbsp bsp/board wr1043nd.bsp`
-* `./buildscript`
+
+* `./buildscript selectbsp bsp/board_ar71xx.bsp`
+* Um die vorhandenen BSPs zu sehen, kann `./buildscript selectbsp help` ausgeführt werden.
 
 ## Was ist ein BSP?
 Ein BSP (Board-Support-Package) beschreibt, was zu tun ist, damit ein Firmware Image für eine spezielle Hardware gebaut werden kann.
@@ -65,10 +65,11 @@ Das Buildscript lädt ebenfalls automatisch das Community file und generiert ein
 * postbuild
   * board_postbuild() wird aufgerufen
 
-### `./buildscript config`
-Um das Arbeiten mit den OpenWrt .config's zu vereinfachen bietet das Buildscript die Möglichkeit die OpenWrt menuconfig und die OpenWrt kernel_menuconfig aufzurufen. Im Anschluss hat man die Möglichkeit die frisch editierten Configs in das BSP zu übernehmen.
+### `./buildscript config openwrt`
+Um das Arbeiten mit den OpenWrt .config's zu vereinfachen bietet das Buildscript die Möglichkeit OpenWrt's menuconfig aufzurufen. Im Anschluss hat man die Möglichkeit die frisch editierten Config in das BSP zu übernehmen.  
+Dieses Kommando arbeitet folgendermaßen:
 * prebuild
-* OpenWrt: `make menuconfig ; make kernel_menuconfig`
+* OpenWrt: `make menuconfig`
 * Speichern, y/n?
 * Config-Format vereinfachen
 * Config ins BSP zurück speichern
@@ -82,7 +83,7 @@ git clone https://github.com/FreifunkFranken/firmware.git
 cd firmware
 ```
 
-### Erstes Images erzeugen
+### Erste Images erzeugen
 Du fügst im board_postbuild ein, dass auch die Images für den wr1043v2 kopiert werden:
 ```
 vim bsp/board_wr1043nd.bsp
@@ -101,7 +102,6 @@ cp bsp/wr1043nd/root_file_system/etc/network.tl-wr1043nd-v1 bsp/wr1043nd/root_fi
 Anschließend kann ein erstes Image erzeugt werden:
 ```
 ./buildscript selectbsp bsp/board_wr1043nd.bsp
-./buildscript selectcommunity community/franken.cfg
 
 ./buildscript prepare
 ./buildscript build

--- a/README.md
+++ b/README.md
@@ -84,15 +84,16 @@ cd firmware
 ```
 
 ### Erste Images erzeugen
-Du fügst im board_postbuild ein, dass auch die Images für den wr1043v2 kopiert werden:
+Du fügst die Dateinamen der Images, die zusätzlich kopiert werden sollen, in das `images`-Array ein:
+
 ```
-vim bsp/board_wr1043nd.bsp
-board_postbuild() {
-    cp $target/bin/ar71xx/openwrt-ar71xx-generic-tl-wr1043nd-v1-squashfs-factory.bin ./bin/
-    cp $target/bin/ar71xx/openwrt-ar71xx-generic-tl-wr1043nd-v1-squashfs-sysupgrade.bin ./bin/
-    cp $target/bin/ar71xx/openwrt-ar71xx-generic-tl-wr1043nd-v2-squashfs-factory.bin ./bin/
-    cp $target/bin/ar71xx/openwrt-ar71xx-generic-tl-wr1043nd-v2-squashfs-sysupgrade.bin ./bin/
-}
+vim bsp/board_ar71xx.bsp
+images=(
+    // ...
+    openwrt-${chipset}-${subtarget}-tl-wr1043nd-v2-squashfs-sysupgrade.bin"
+    openwrt-${chipset}-${subtarget}-tl-wr1043nd-v2-squashfs-factpry.bin"
+    // ...
+)
 ```
 
 Dann muss auf jeden Fall noch das Netzwerk richtig konfiguriert werden. Dazu muss man den Router sehr gut kennen, i.d.R. lernt man den erst beim Verwenden kennen, daher ist ein guter Startpunkt die Config vom v1 zu kopieren und erstmal zu gucken was passiert:


### PR DESCRIPTION
Das README scheint etwas in die Jahre gekommen zu sein, daher habe ich mal angefangen, es aufzuräumen, u.a.:

- Erwähnungen des "selectcommunity"-Kommandos entfernt
- Nicht vorhandene BSP-Dateinamen entfernt
- buildscript-Aufrufe korrigiert

Das sind insbesondere die Stellen, über die ich gestolpert bin, als ich das Image kompilieren wollte.

Offene Fragen:
- Abschnitt "Was ist ein BSP?" - der Dateibaum stimmt so nicht mehr. Soll ich die Struktur einfach aktualisieren? Wo sind die erwähnten Dateien hingekommen? (s.a. nächste Frage)
- Abschnitt "Erweiterung eines BSPs" - die Dateien gibt es so nicht mehr (z.B. network.tl-wr1043nd-v1) - was soll mit dem Abschnitt geschehen?
